### PR TITLE
Added options to Excon connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,22 @@ abq = AbiquoAPI.new(:abiquo_api_url => 'https://10.60.13.40/api',
                   :version => "2.9")
 ```
 
+You can also define some connection parameters that will be applied to HTTP connection:
+
+```ruby
+require 'abiquo-api'
+
+abq = AbiquoAPI.new(:abiquo_api_url => 'https://10.60.13.40/api',
+                  :abiquo_username => "admin",
+                  :abiquo_password => "xabiquo",
+                  :connection_options => {
+                      :connect_timeout => 30,
+                      :read_timeout => 120,
+                      :write_timeout => 120,
+                      :ssl_verify_peer => true,
+                      :ssl_ca_path => "/etc/pki/tls/private/myCA.crt" })
+```
+
 Then you can start browsing the API:
 
 ```ruby

--- a/lib/abiquo-api.rb
+++ b/lib/abiquo-api.rb
@@ -38,22 +38,31 @@ class AbiquoAPI
   #
   # Required options:
   #
-  #   :abiquo_api_url  => The URL of the Abiquo API. ie. https://yourserver/api
-  #   :abiquo_username => The username used to connect to the Abiquo API.
-  #   :abiquo_password => The password for your user.
-  #   :version         => The Abiquo API version to include in each request.
-  #                       Defaults to whatever is returned in the /api/version resource
+  #   :abiquo_api_url     => The URL of the Abiquo API. ie. https://yourserver/api
+  #   :abiquo_username    => The username used to connect to the Abiquo API.
+  #   :abiquo_password    => The password for your user.
+  #   :version            => The Abiquo API version to include in each request.
+  #                          Defaults to whatever is returned in the /api/version resource
+  #   :connection_options => Excon HTTP client connection options.
+  #                          { :connect_timeout => <time_in_secs>,
+  #                            :read_timeout => <time_in_secs>,
+  #                            :write_timeout => <time_in_secs>,
+  #                            :ssl_verify_peer => <true_or_false>,
+  #                            :ssl_ca_path => <path_to_ca_file> }
   #
   def initialize(options = {})
     api_url = options[:abiquo_api_url]
     api_username = options[:abiquo_username]
     api_password = options[:abiquo_password]
+    connection_options = options[:connection_options] || {}
 
     raise "You need to set :abiquo_api_url, :abiquo_username and :abiquo_password" if api_url.nil? or api_username.nil? or api_password.nil?
 
     @http_client = AbiquoAPIClient::HTTPClient.new(api_url,
                                                   api_username,
-                                                  api_password)
+                                                  api_password,
+                                                  connection_options)
+
     api_path = URI.parse(api_url).path
 
     loginresp = @http_client.request(

--- a/lib/abiquo-api/httpclient.rb
+++ b/lib/abiquo-api/httpclient.rb
@@ -28,12 +28,24 @@ module AbiquoAPIClient
     #   :abiquo_api_url:: The URL of the Abiquo API. ie. https://yourserver/api
     #   :abiquo_username:: The username used to connect to the Abiquo API.
     #   :abiquo_password:: The password for your user.
+    #   :connection_options:: { :connect_timeout => <time_in_secs>, :read_timeout => <time_in_secs>, :write_timeout => <time_in_secs>,
+    #                           :ssl_verify_peer => <true_or_false>, :ssl_ca_path => <path_to_ca_file> }
     #
-    def initialize(api_url, api_username, api_password)
-      Excon.defaults[:ssl_verify_peer] = false
+    def initialize(api_url, api_username, api_password, connection_options)
+      Excon.defaults[:ssl_ca_path] = connection_options[:ssl_ca_path] || ''
+      Excon.defaults[:ssl_verify_peer] = connection_options[:ssl_verify_peer] || false
+
+      connect_timeout  = connection_options[:connect_timeout] || 60
+      read_timeout = connection_options[:read_timeout] || 60
+      write_timeout = connection_options[:write_timeout] || 60
+
       @connection = Excon.new(api_url, 
                             :user => api_username, 
-                            :password => api_password )
+                            :password => api_password,
+                            :connect_timeout => connect_timeout,
+                            :read_timeout => read_timeout,
+                            :write_timeout => write_timeout)
+
       self
     end
 

--- a/lib/abiquo-api/version.rb
+++ b/lib/abiquo-api/version.rb
@@ -1,3 +1,3 @@
 module AbiquoAPIClient
-  VERSION = '0.0.4'
+  VERSION = '0.0.5'
 end


### PR DESCRIPTION
Added configuration parameters to Excon HTTP client connection.
Taken by reference [Excon](https://github.com/excon/excon#options) documentation and [HP Cloud](https://dev.hpcloud.com/ruby/sdk-connect.html#timeouts) Fog binding to add these options.

Also bumped version.
